### PR TITLE
Implement advanced parameters system

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -123,7 +123,13 @@ function buildRequest(name, parameters, configuration) {
     payload.cache = configuration.c === true ? configuration.ct : -1
   }
 
-  const buildParam = param.build(parameters, configuration)
+  let buildParam
+  if (configuration.simpleParameters === false) {
+    buildParam = param.buildAdvanced(parameters, configuration)
+  } else {
+    buildParam = param.build(parameters, configuration)
+  }
+
   if (buildParam) {
     payload.parm = buildParam
   }

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -133,6 +133,35 @@ describe('OpenEdge', () => {
 
       expect(result.proc).toStrictEqual(expectedResult)
     })
+
+    test('should handle parameters in advanced manner', () => {
+      const expectedResult = [
+        { pos: 1, value: 1, type: 'integer', redact: true }
+      ]
+      const parameters = [
+        { value: 1, redact: true }
+      ]
+
+
+      const configuration = {
+        c: true,
+        ct: 60000,
+        tw: 5000,
+        creds: {
+          user: 'oe-server',
+          password: 'password'
+        },
+        parameterDefaults: {
+          in: 'string',
+          out: 'json'
+        },
+        simpleParameters: false
+      }
+
+      const result = oe.test('testProcedure', parameters, configuration)
+
+      expect(result.parm).toStrictEqual(expectedResult)
+    })
   })
   describe('run()', () => {
     test('Should throw when no procedure name is supplied', () => {

--- a/src/oe-param.js
+++ b/src/oe-param.js
@@ -39,7 +39,7 @@ function buildAdvanced(parameters, configuration) {
   const parameterResult = []
 
   for (const [i, param] of parameters.entries()) {
-    if (!param) {
+    if (param?.out) {
       parameterResult.push(getAdvancedOutputParameter(i + 1, param, configuration))
     } else {
       parameterResult.push(
@@ -178,12 +178,6 @@ function resolveParameterType(param, configuration) {
         return 'def'
 
       break
-    case configuration.parameterDefaults.out:
-      if (isOutParameter)
-        return 'def'
-
-      break
-
     case 'number':
       return 'integer'
 

--- a/src/oe-param.js
+++ b/src/oe-param.js
@@ -39,18 +39,27 @@ function buildAdvanced(parameters, configuration) {
   const parameterResult = []
 
   for (const [i, param] of parameters.entries()) {
-    if (param?.out) {
-      parameterResult.push(getAdvancedOutputParameter(i + 1, param, configuration))
-    } else {
-      parameterResult.push(
-        param.value === undefined ?
-          getAdvancedOutputParameter(i + 1, param, configuration) :
-          getAdvancedInputParameter(i + 1, param, configuration)
-      )
-    }
+    parameterResult.push(getAdvancedParameter(i + 1, param, configuration))
   }
 
   return parameterResult
+}
+
+/**
+ * Retrieve either advanced parameter result
+ * @param {Number} index 
+ * @param {Object} parameter 
+ * @param {Object} configuration 
+ * @returns a parameter object in OE-connector format
+ */
+function getAdvancedParameter(index, parameter, configuration) {
+  if (parameter?.out) {
+    return getAdvancedOutputParameter(index, parameter, configuration)
+  } else {
+    return parameter.value === undefined ?
+        getAdvancedOutputParameter(index, parameter, configuration) :
+        getAdvancedInputParameter(index, parameter, configuration)
+  }
 }
 
 /**
@@ -182,11 +191,7 @@ function resolveParameterType(param, configuration) {
       return 'integer'
 
     case 'object':
-      if (isOutParameter && configuration.parameterDefaults.out === 'json') {
-        return 'def'
-      } else {
-        return 'json'
-      }
+      return getOutputObjectParameterType(configuration, isOutParameter)
   }
   return paramType
 }
@@ -199,6 +204,20 @@ function handleParameterFinalType(parameter) {
   if (!parameter.type || parameter.type === 'def') {
     delete parameter.type
   }
+}
+
+/**
+ * Retrieve the output parameter type if the parameter type is an object
+ * @param {*} configuration 
+ * @param {*} isOutParameter 
+ * @returns either 'json' or 'def' if json is the default configured output type
+ */
+function getOutputObjectParameterType(configuration, isOutParameter) {
+  if (isOutParameter && configuration.parameterDefaults.out === 'json') {
+    return 'def'
+  }
+
+  return 'json'
 }
 
 module.exports = {

--- a/src/oe-param.test.js
+++ b/src/oe-param.test.js
@@ -1,3 +1,4 @@
+const { test } = require('@jest/globals')
 const param = require('./oe-param')
 
 describe('oe-param', () => {
@@ -34,6 +35,122 @@ describe('oe-param', () => {
 
 
       expect(result).toStrictEqual(expectedResult)
+    })
+  })
+
+  describe('getInputParameter', () => {
+    const configuration = { parameterDefaults: { in: 'json' }}
+    test('should return correct input parameter object', () => {
+      const value = { foo: 'bar', base64: Buffer.from('test', 'base64') }
+      const expectedResult = {
+        pos: 1, type: "json", value
+      }
+
+      const result = param.getInputParameter(1, value, configuration)
+
+      expect(result).toStrictEqual(expectedResult)
+    })
+  })
+
+  describe('getAdvancedInputParameter', () => {
+    const configuration = {
+      parameterDefaults: {
+        in: 'string',
+        out: 'json'
+      }
+    }
+
+    const advancedInputLabelTests = [
+      ['test123', 'test123'],
+      ['test', 'test'],
+      [undefined, undefined],
+      [null, undefined],
+      [false, undefined]
+    ]
+    test.each(advancedInputLabelTests)('should set label correct', (label, expectedLabel) => {
+      const parameter = param.getAdvancedInputParameter(13, { value: 1, label }, configuration)
+
+      expect(parameter.label).toStrictEqual(expectedLabel)
+    })
+
+
+    const advancedInputTypeTests = [
+      ['object', 'json'],
+      ['json', 'json'],
+      ['string', undefined],
+      [undefined, 'integer'],
+      [null, 'integer'],
+      [false, undefined]
+    ]
+    test.each(advancedInputTypeTests)('should set correct input type', (type, expectedType) => {
+      const parameter = param.getAdvancedInputParameter(13, { value: 1, type }, configuration)
+
+      expect(parameter.type).toStrictEqual(expectedType)
+    })
+
+    const truthyTests = [ [true], [{}], [[]], ['test'], [1]]
+    test.each(truthyTests)('should add redact to parameter', (redact) => {
+      const parameter = param.getAdvancedInputParameter(13, { value: 1, redact }, configuration)
+
+      expect(parameter.redact).toBe(true)
+    })
+    const falsyTests = [ [false], [null], [undefined] ]
+    test.each(falsyTests)('should leave redact from parameter', (redact) => {
+      const parameter = param.getAdvancedInputParameter(13, { value: 1, redact  }, configuration)
+
+      expect(parameter.redact).toStrictEqual(undefined)
+    })
+  })
+
+  describe('getAdvancedOutputParameter', () => {
+    const configuration = {
+      parameterDefaults: {
+        in: 'json',
+        out: 'json'
+      }
+    }
+    test('should set correct index and out parameter fields', () => {
+      const parameter = param.getAdvancedOutputParameter(2, { type: 'string' }, configuration)
+
+      expect(parameter.pos).toBe(2)
+      expect(parameter.out).toBe(true)
+    })
+
+
+    const parameterTypeTests = [
+      [ null, undefined ],
+      [ undefined, undefined ],
+      [ 'string', 'string' ],
+      [ 'number', 'integer' ],
+      [ 'integer', 'integer' ],
+      [ 'object', undefined ],
+      [ 'json', undefined ]
+    ]
+    test.each(parameterTypeTests)('should set correct parameter type',
+      (type, expectedType) => {
+        const parameter = param.getAdvancedOutputParameter(13, { type  }, configuration)
+
+        expect(parameter.type).toStrictEqual(expectedType)
+      })
+
+    const parameterForceArrayTests = [ [true, true], [false, undefined],
+      [undefined, undefined], [null, undefined] ]
+    test.each(parameterForceArrayTests)('should force array correctly', (ar, expectedForceArray) => {
+      const parameter = param.getAdvancedOutputParameter(13, { type: 'string', ar }, configuration)
+
+      expect(parameter.ar).toStrictEqual(expectedForceArray)
+    })
+
+    const parameterLabelTests = [ 
+      ['test', 'test'],
+      [undefined, undefined],
+      [null, undefined],
+      [false, undefined]
+    ]
+    test.each(parameterLabelTests)('should set label if present and valid', (label, expectedLabel) => {
+      const parameter = param.getAdvancedOutputParameter(13, { type: 'string', label }, configuration)
+
+      expect(parameter.label).toStrictEqual(expectedLabel)
     })
   })
 })

--- a/src/oe-param.test.js
+++ b/src/oe-param.test.js
@@ -50,6 +50,16 @@ describe('oe-param', () => {
 
       expect(result).toStrictEqual(expectedResult)
     })
+
+    test('should not set parameter type if parameter is NULL', () => {
+      const expectedResult = {
+        pos: 1, value: null
+      }
+
+      const result = param.getInputParameter(1, null, configuration)
+
+      expect(result).toStrictEqual(expectedResult)
+    })
   })
 
   describe('getAdvancedInputParameter', () => {


### PR DESCRIPTION
Currently only simple parameters are implemented, allowing the lib to convert simple objects into OE-Connector parameter format.

This is fast, and simple, but lacks all the advanced feature's like redacting parameters from logging, forcing encapsulating arrays on outputs and adding labels instead of positions.

This PR should hopefully address all of that.